### PR TITLE
Use LastIndexOf to locate rule match in domain

### DIFF
--- a/DomainName.Library/DomainName.cs
+++ b/DomainName.Library/DomainName.cs
@@ -142,13 +142,13 @@ namespace DomainName.Library
             switch (MatchingRule.Type)
             {
                 case TLDRule.RuleType.Normal:
-                    tldIndex = domainString.IndexOf("." + MatchingRule.Name, StringComparison.InvariantCultureIgnoreCase);
+                    tldIndex = domainString.LastIndexOf("." + MatchingRule.Name, StringComparison.InvariantCultureIgnoreCase);
                     tempSudomainAndDomain = domainString.Substring(0, tldIndex);
                     TLD = domainString.Substring(tldIndex + 1);
                     break;
                 case TLDRule.RuleType.Wildcard:
                     //  This finds the last portion of the TLD...
-                    tldIndex = domainString.IndexOf("." + MatchingRule.Name, StringComparison.InvariantCultureIgnoreCase);
+                    tldIndex = domainString.LastIndexOf("." + MatchingRule.Name, StringComparison.InvariantCultureIgnoreCase);
                     tempSudomainAndDomain = domainString.Substring(0, tldIndex);
 
                     //  But we need to find the wildcard portion of it:

--- a/DomainName.Tests/DomainTests.cs
+++ b/DomainName.Tests/DomainTests.cs
@@ -113,6 +113,47 @@ namespace DomainName.Tests
                 string.Format("Looks like the parsed domain part is: {0}", outDomain.Domain)
                 );
         }
+        
+        [TestMethod]
+        public void ParseNormalDomainWhereTLDOccursInDomain()
+        {
+            //  Try parsing a 'normal' domain where the TLD part also occurs in the domain part
+            DomainName.Library.DomainName.TryParse("russian.cntv.cn", out outDomain);
 
+            //  The domain should be parsed as 'cntv'
+            Assert.AreEqual<string>("cntv", outDomain.Domain);
+
+            Debug.WriteLine(
+                string.Format("Looks like the parsed domain part is: {0}", outDomain.Domain)
+                );
+        }
+
+        [TestMethod]
+        public void ParseWildcardDomainWhereTLDOccursInDomain()
+        {
+            //  Try parsing a 'wildcard' domain where the TLD part also occurs in the domain part
+            DomainName.Library.DomainName.TryParse("com.er.com.er", out outDomain);
+
+            //  The domain should be parsed as 'er'
+            Assert.AreEqual<string>("er", outDomain.Domain);
+
+            Debug.WriteLine(
+                string.Format("Looks like the parsed domain part is: {0}", outDomain.Domain)
+                );
+        }
+
+        [TestMethod]
+        public void ParseExceptionDomainWhereTLDOccursInSubdomain()
+        {
+            //  Try parsing an 'exception' domain where the TLD part also occurs in the subdomain part
+            DomainName.Library.DomainName.TryParse("www.ck.www.ck", out outDomain);
+
+            //  The domain should be parsed as 'www'
+            Assert.AreEqual<string>("www", outDomain.Domain);
+
+            Debug.WriteLine(
+                string.Format("Looks like the parsed domain part is: {0}", outDomain.Domain)
+                );
+        }
     }
 }


### PR DESCRIPTION
I'd like to resolve #4 with the fix proposed by @alexwarren. I also fixed a similar issue with wildcard domains (that one is much less likely to occur). I've added a test for each case of normal, wildcard and exception domains.