### PR TITLE
Performance improvements to enable faster lookups 

### DIFF
--- a/DomainName.Library/DomainName.cs
+++ b/DomainName.Library/DomainName.cs
@@ -257,56 +257,17 @@ namespace DomainName.Library
                 if (checkAgainst.EndsWith("."))
                     checkAgainst = checkAgainst.Substring(0, checkAgainst.Length - 1);
 
-                //  Try to match an exception rule:
-                var exceptionresults = from test in TLDRulesCache.Instance.TLDRuleList
-                                       where
-                                         test.Name.Equals(checkAgainst, StringComparison.InvariantCultureIgnoreCase)
-                                         &&
-                                         test.Type == TLDRule.RuleType.Exception
-                                       select
-                                         test;
-
-                //  Add our matches:
-                ruleMatches.AddRange(exceptionresults.ToList());
-
-                //  See if we have a match yet.
-                Debug.WriteLine(
-                    string.Format("Domain part {0} matched {1} exception rules", checkAgainst, exceptionresults.Count())
-                    );
-
-                //  Try to match an exception rule:
-                var wildcardresults = from test in TLDRulesCache.Instance.TLDRuleList
-                                      where
-                                        test.Name.Equals(checkAgainst, StringComparison.InvariantCultureIgnoreCase)
-                                        &&
-                                        test.Type == TLDRule.RuleType.Wildcard
-                                      select
-                                        test;
-
-                //  Add our matches:
-                ruleMatches.AddRange(wildcardresults.ToList());
-
-                //  See if we have a match yet.
-                Debug.WriteLine(
-                    string.Format("Domain part {0} matched {1} wildcard rules", checkAgainst, wildcardresults.Count())
-                    );
-
-                //  Try to match a normal rule:
-                var normalresults = from test in TLDRulesCache.Instance.TLDRuleList
-                                    where
-                                      test.Name.Equals(checkAgainst, StringComparison.InvariantCultureIgnoreCase)
-                                      &&
-                                      test.Type == TLDRule.RuleType.Normal
-                                    select
-                                      test;
-
-                //  See if we have a match yet.
-                Debug.WriteLine(
-                    string.Format("Domain part {0} matched {1} normal rules", checkAgainst, normalresults.Count())
-                    );
-
-                //  Add our matches:
-                ruleMatches.AddRange(normalresults.ToList());
+                var rules = Enum.GetValues(typeof(TLDRule.RuleType)).Cast<TLDRule.RuleType>();
+                foreach (var rule in rules)
+                {
+                    //  Try to match rule:
+                    TLDRule result;
+                    if (TLDRulesCache.Instance.TLDRuleLists[rule].TryGetValue(checkAgainst, out result))
+                    {
+                        ruleMatches.Add(result);
+                        Debug.WriteLine(string.Format("Domain part {0} matched {1} rule", checkAgainst, rule));
+                    }
+                }
             }
 
             //  Sort our matches list (longest rule wins, according to :

--- a/DomainName.Library/DomainName.cs
+++ b/DomainName.Library/DomainName.cs
@@ -265,8 +265,8 @@ namespace DomainName.Library
                     if (TLDRulesCache.Instance.TLDRuleLists[rule].TryGetValue(checkAgainst, out result))
                     {
                         ruleMatches.Add(result);
-                        Debug.WriteLine(string.Format("Domain part {0} matched {1} rule", checkAgainst, rule));
                     }
+                    Debug.WriteLine(string.Format("Domain part {0} matched {1} {2} rules", checkAgainst, result == null ? 0 : 1, rule));
                 }
             }
 

--- a/DomainName.Library/TLDRulesCache.cs
+++ b/DomainName.Library/TLDRulesCache.cs
@@ -14,13 +14,13 @@ namespace DomainName.Library
         private static volatile TLDRulesCache _uniqueInstance;
         private static object _syncObj = new object();
         private static object _syncList = new object();
-        private List<TLDRule> _lstTLDRules;
+
+        private IDictionary<TLDRule.RuleType, IDictionary<string, TLDRule>> _lstTLDRules;
 
         private TLDRulesCache()
         {
             //  Initialize our internal list:
             _lstTLDRules = GetTLDRules();
-            _lstTLDRules.Sort();
         }
 
         /// <summary>
@@ -45,7 +45,7 @@ namespace DomainName.Library
         /// <summary>
         /// List of TLD rules
         /// </summary>
-        public List<TLDRule> TLDRuleList
+        public IDictionary<TLDRule.RuleType, IDictionary<string, TLDRule>> TLDRuleLists
         {
             get
             {
@@ -73,24 +73,25 @@ namespace DomainName.Library
         /// Gets the list of TLD rules from the cache
         /// </summary>
         /// <returns></returns>
-        private List<TLDRule> GetTLDRules()
+        private IDictionary<TLDRule.RuleType, IDictionary<string, TLDRule>> GetTLDRules()
         {
-            List<TLDRule> results = new List<TLDRule>();
+            var results = new Dictionary<TLDRule.RuleType, IDictionary<string, TLDRule>>();
+            var rules = Enum.GetValues(typeof(TLDRule.RuleType)).Cast<TLDRule.RuleType>();
+            foreach (var rule in rules)
+            {
+                results[rule] = new Dictionary<string, TLDRule>(StringComparer.InvariantCultureIgnoreCase);
+            }
 
             var ruleStrings = ReadRulesData();           
 
             //  Strip out any lines that are:
             //  a.) A comment
             //  b.) Blank
-            IEnumerable<TLDRule> lstTLDRules = from ruleString in ruleStrings
-                                               where
-                                               !ruleString.StartsWith("//", StringComparison.InvariantCultureIgnoreCase)
-                                               &&
-                                               !(ruleString.Trim().Length == 0)
-                                               select new TLDRule(ruleString);
-
-            //  Transfer this list to the results:
-            results = lstTLDRules.ToList();
+            foreach (var ruleString in ruleStrings.Where(ruleString => !ruleString.StartsWith("//", StringComparison.InvariantCultureIgnoreCase) && ruleString.Trim().Length != 0))
+            {
+                var result = new TLDRule(ruleString);
+                results[result.Type][result.Name] = result;
+            }
 
             //  Return our results:
             Debug.WriteLine(string.Format("Loaded {0} rules into cache.", results.Count));

--- a/DomainName.Library/TLDRulesCache.cs
+++ b/DomainName.Library/TLDRulesCache.cs
@@ -94,7 +94,7 @@ namespace DomainName.Library
             }
 
             //  Return our results:
-            Debug.WriteLine(string.Format("Loaded {0} rules into cache.", results.Count));
+            Debug.WriteLine(string.Format("Loaded {0} rules into cache.", results.Values.Sum(r => r.Values.Count)));
             return results;
         }
 

--- a/DomainName.Tests/TLDRulesCacheTests.cs
+++ b/DomainName.Tests/TLDRulesCacheTests.cs
@@ -65,10 +65,15 @@ namespace DomainName.Tests
             //  We should have more than 0 rules loaded.  If we don't, it's probably because
             //  we need to get the rules cache from http://publicsuffix.org/list/ and haven't yet
             //  or the component needs to be configured to look in the correct spot.
-            Assert.IsTrue(TLDRulesCache.Instance.TLDRuleList.Count > 0);
+            Assert.IsTrue(TLDRulesCache.Instance.TLDRuleLists.Count > 0);
+            Assert.IsTrue(TLDRulesCache.Instance.TLDRuleLists.Values.All(list => list.Count > 0));
 
             Debug.WriteLine(
-                string.Format("There are {0} rules loaded from the cache.", TLDRulesCache.Instance.TLDRuleList.Count)
+                string.Format("There are {0} rule lists loaded from the cache.", TLDRulesCache.Instance.TLDRuleLists.Count)
+                );
+
+            Debug.WriteLine(
+                string.Format("There are {0} rules loaded from the cache.", TLDRulesCache.Instance.TLDRuleLists.Values.Select(list => list.Count).Sum())
                 );
         }
     }


### PR DESCRIPTION
I made some performance improvements to enable faster lookups when dealing with large numbers of domains.

On a sample of 10000 domains, before the changes a full run on my machine took 102 seconds and after the changes it took 6 seconds.

Those times include the initial setup of pulling down the .dat file so over a larger sample (e.g. millions), the improvements are more pronounced.

The main change is that when building the TLDRulesCache, the TLDRules are stored in dictionaries, one per RuleType, indexed by TLDRule.Name. Then when checking for results in DomainName, the lookups are done against these dictionaries. The dictionaries use the same InvariantCultureIgnoreCase StringComparer as the previous list lookups.

The 3 RuleType dictionaries are stored in another dictionary indexed by RuleType. This allows reuse of the code for populating and looking up dictionaries, by enumerating over the values of RuleType.
