### PR TITLE
Some performance changes

### DIFF
--- a/DomainParser.Library/DomainName.cs
+++ b/DomainParser.Library/DomainName.cs
@@ -257,7 +257,7 @@ namespace DomainParser.Library
                     checkAgainst = checkAgainst.Substring(0, checkAgainst.Length - 1);
 
                 var rules = Enum.GetValues(typeof(TLDRule.RuleType)).Cast<TLDRule.RuleType>();
-                var ruleList = TLDRulesCache.Instance.GetTLDRuleLists();
+                var ruleList = TLDRulesCache.Instance.GetTLDRuleList();
 
                 foreach (var rule in rules)
                 {

--- a/DomainParser.Library/DomainName.cs
+++ b/DomainParser.Library/DomainName.cs
@@ -257,11 +257,13 @@ namespace DomainParser.Library
                     checkAgainst = checkAgainst.Substring(0, checkAgainst.Length - 1);
 
                 var rules = Enum.GetValues(typeof(TLDRule.RuleType)).Cast<TLDRule.RuleType>();
+                var ruleList = TLDRulesCache.Instance.GetTLDRuleLists();
+
                 foreach (var rule in rules)
                 {
                     //  Try to match rule:
                     TLDRule result;
-                    if (TLDRulesCache.Instance.TLDRuleLists[rule].TryGetValue(checkAgainst, out result))
+                    if (ruleList[rule].TryGetValue(checkAgainst, out result))
                     {
                         ruleMatches.Add(result);
                     }

--- a/DomainParser.Library/TLDRulesCache.cs
+++ b/DomainParser.Library/TLDRulesCache.cs
@@ -14,7 +14,7 @@ namespace DomainParser.Library
         private static volatile TLDRulesCache _uniqueInstance;
         private static object _syncObj = new object();
         private static object _syncList = new object();
-		private static object _syncData = new object();
+        private static object _syncData = new object();
 
 
         /// <summary>
@@ -95,8 +95,6 @@ namespace DomainParser.Library
                     }
                 }
 
-                _uniqueInstance.CheckRuleList();
-
                 return (_uniqueInstance);
             }
         }
@@ -117,12 +115,26 @@ namespace DomainParser.Library
         {
             get
             {
+                if (_lstTLDRules == null) {
+                    _lstTLDRules = GetTLDRules();
+                }
                 return _lstTLDRules;
             }
             set
             {
                 _lstTLDRules = value;
             }
+        }
+
+        /// <summary>
+        /// Preferable method to get the TLDRuleList. This method checks the availability and/or expiration of the rule list.
+        /// </summary>
+        /// <returns></returns>
+        public IDictionary<TLDRule.RuleType, IDictionary<string, TLDRule>> GetTLDRuleLists() {
+ 
+            CheckRuleList();
+            return _lstTLDRules;
+
         }
 
         /// <summary>

--- a/DomainParser.Library/TLDRulesCache.cs
+++ b/DomainParser.Library/TLDRulesCache.cs
@@ -130,7 +130,7 @@ namespace DomainParser.Library
         /// Preferable method to get the TLDRuleList. This method checks the availability and/or expiration of the rule list.
         /// </summary>
         /// <returns></returns>
-        public IDictionary<TLDRule.RuleType, IDictionary<string, TLDRule>> GetTLDRuleLists() {
+        public IDictionary<TLDRule.RuleType, IDictionary<string, TLDRule>> GetTLDRuleList() {
  
             CheckRuleList();
             return _lstTLDRules;


### PR DESCRIPTION
Changed the way the TLDRuleList is checked for expiration and availablity. 

In the rules list iteration of the DomainName.FindMatchingTLDRule method, the static instance of the TLDRulesCache was referenced directly. This caused the CheckRuleList method to get called for every iteration (because of the get access method).
I introduced a new method on the TLDRulesCache to get the rules list which is used in the DomainName.FindMatchingTLDRule to get the list prior to the iteration.
